### PR TITLE
Move all printing into loglevels

### DIFF
--- a/src/archive/chd.rs
+++ b/src/archive/chd.rs
@@ -1,10 +1,10 @@
-use log::info;
 use std::error::Error;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
 use chd::Chd;
+use log::debug;
 
 use crate::console::psx::{self, PsxAnalysis};
 use crate::console::segacd::{self, SegaCdAnalysis};
@@ -25,7 +25,7 @@ pub fn analyze_chd_file(filepath: &Path, source_name: &str) -> Result<ChdAnalysi
     let hunk_count = chd.header().hunk_count();
     let hunk_size = chd.header().hunk_size();
 
-    info!(
+    debug!(
         "[+] Analyzing CHD file: {}",
         filepath
             .file_name()
@@ -54,7 +54,7 @@ pub fn analyze_chd_file(filepath: &Path, source_name: &str) -> Result<ChdAnalysi
         decompressed_data.extend_from_slice(&out_buf[..data_to_add]);
     }
 
-    info!(
+    debug!(
         "[+] Decompressed first {} bytes for header analysis.",
         decompressed_data.len()
     );

--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -1,13 +1,13 @@
-use log::{error, info};
 use std::error::Error;
 use std::fs::File;
 use std::io::Read;
+
+use log::{debug, error};
 use zip::ZipArchive;
 
 use crate::RomAnalysisResult;
-use crate::error::RomAnalyzerError;
-
 use crate::SUPPORTED_ROM_EXTENSIONS;
+use crate::error::RomAnalyzerError;
 
 pub fn process_zip_file(
     file: File,
@@ -17,7 +17,7 @@ pub fn process_zip_file(
     let mut archive = ZipArchive::new(file)?;
     let mut found_rom = false;
 
-    info!("[+] Analyzing ZIP archive: {}", original_filename);
+    debug!("[+] Analyzing ZIP archive: {}", original_filename);
 
     for i in 0..archive.len() {
         let mut file_in_zip = archive.by_index(i)?;
@@ -33,7 +33,7 @@ pub fn process_zip_file(
             .any(|ext| lower_entry_name.ends_with(ext));
 
         if is_supported_rom {
-            info!("[+] Found supported ROM in zip: {}", entry_name);
+            debug!("[+] Found supported ROM in zip: {}", entry_name);
             found_rom = true;
             let mut data = Vec::new();
             file_in_zip.read_to_end(&mut data)?;

--- a/src/console/gamegear.rs
+++ b/src/console/gamegear.rs
@@ -1,8 +1,11 @@
+/// GameGear header documentation referenced here:
 /// https://www.smspower.org/Development/ROMHeader
+use std::error::Error;
+
+use log::{debug, info};
+
 use crate::print_separator;
 use crate::region::infer_region_from_filename;
-use log::debug;
-use std::error::Error;
 
 const POSSIBLE_HEADER_STARTS: &[usize] = &[0x7ff0, 0x3ff0, 0x1ff0];
 const REGION_CODE_OFFSET: usize = 0xf;
@@ -23,11 +26,11 @@ impl GameGearAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Sega Game Gear");
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Sega Game Gear");
+        info!("Region:       {}", self.region);
         if !self.region_found {
-            println!("Note:         Region information not in ROM header, inferred from filename.");
+            info!("Note:         Region information not in ROM header, inferred from filename.");
         }
         print_separator();
     }

--- a/src/console/gb.rs
+++ b/src/console/gb.rs
@@ -1,5 +1,8 @@
+/// Gameboy/Color header documentation referenced here:
 /// https://gbdev.io/pandocs/The_Cartridge_Header.html
 use std::error::Error;
+
+use log::info;
 
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
@@ -30,11 +33,11 @@ impl GbAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       {}", self.system_type);
-        println!("Game Title:   {}", self.game_title);
-        println!("Region Code:  0x{:02X}", self.destination_code);
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       {}", self.system_type);
+        info!("Game Title:   {}", self.game_title);
+        info!("Region Code:  0x{:02X}", self.destination_code);
+        info!("Region:       {}", self.region);
 
         print_separator();
     }

--- a/src/console/gba.rs
+++ b/src/console/gba.rs
@@ -1,5 +1,8 @@
+/// GBA header documentation referenced here:
 /// https://problemkaputt.de/gbatek-gba-cartridge-header.htm
 use std::error::Error;
+
+use log::info;
 
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
@@ -23,12 +26,12 @@ impl GbaAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Game Boy Advance (GBA)");
-        println!("Game Title:   {}", self.game_title);
-        println!("Game Code:    {}", self.game_code);
-        println!("Maker Code:   {}", self.maker_code);
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Game Boy Advance (GBA)");
+        info!("Game Title:   {}", self.game_title);
+        info!("Game Code:    {}", self.game_code);
+        info!("Maker Code:   {}", self.maker_code);
+        info!("Region:       {}", self.region);
 
         print_separator();
     }

--- a/src/console/genesis.rs
+++ b/src/console/genesis.rs
@@ -1,7 +1,8 @@
+/// Genesis header documentation referenced here:
 /// https://plutiedev.com/rom-header#system
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
-use log::error;
+use log::{error, info};
 use std::error::Error;
 
 const SYSTEM_TYPE_START: usize = 0x100;
@@ -33,15 +34,15 @@ impl GenesisAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       {}", self.console_name);
-        println!("Game Title (Domestic): {}", self.game_title_domestic);
-        println!("Game Title (Int.):   {}", self.game_title_international);
-        println!(
+        info!("Source:       {}", self.source_name);
+        info!("System:       {}", self.console_name);
+        info!("Game Title (Domestic): {}", self.game_title_domestic);
+        info!("Game Title (Int.):   {}", self.game_title_international);
+        info!(
             "Region Code:  0x{:02X} ('{}')",
             self.region_code_byte, self.region_code_byte as char
         );
-        println!("Region:       {}", self.region);
+        info!("Region:       {}", self.region);
 
         print_separator();
     }

--- a/src/console/mastersystem.rs
+++ b/src/console/mastersystem.rs
@@ -1,4 +1,7 @@
+/// Master System header documentation referenced here:
 /// https://www.smspower.org/Development/ROMHeader
+use log::info;
+
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
 use std::error::Error;
@@ -18,10 +21,10 @@ impl MasterSystemAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Sega Master System");
-        println!("Region Code:  0x{:02X}", self.region_byte);
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Sega Master System");
+        info!("Region Code:  0x{:02X}", self.region_byte);
+        info!("Region:       {}", self.region);
 
         print_separator();
     }

--- a/src/console/n64.rs
+++ b/src/console/n64.rs
@@ -1,5 +1,8 @@
+/// N64 header documentation referenced here:
 /// https://en64.shoutwiki.com/wiki/ROM
 use std::error::Error;
+
+use log::info;
 
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
@@ -19,10 +22,10 @@ impl N64Analysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Nintendo 64 (N64)");
-        println!("Region:       {}", self.region);
-        println!("Code:         {}", self.country_code);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Nintendo 64 (N64)");
+        info!("Region:       {}", self.region);
+        info!("Code:         {}", self.country_code);
 
         print_separator();
     }

--- a/src/console/nes.rs
+++ b/src/console/nes.rs
@@ -1,9 +1,11 @@
+/// NES header documentation referenced here:
 /// https://www.nesdev.org/wiki/INES
 /// https://www.nesdev.org/wiki/NES_2.0
 use std::error::Error;
 
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
+use log::info;
 
 const INES_REGION_BYTE: usize = 9;
 const INES_REGION_MASK: u8 = 0x01;
@@ -31,13 +33,13 @@ impl NesAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Nintendo Entertainment System (NES)");
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Nintendo Entertainment System (NES)");
+        info!("Region:       {}", self.region);
         if self.is_nes2_format {
-            println!("NES2.0 Flag 12: 0x{:02X}", self.region_byte_value);
+            info!("NES2.0 Flag 12: 0x{:02X}", self.region_byte_value);
         } else {
-            println!("iNES Flag 9:  0x{:02X}", self.region_byte_value);
+            info!("iNES Flag 9:  0x{:02X}", self.region_byte_value);
         }
         print_separator();
     }

--- a/src/console/psx.rs
+++ b/src/console/psx.rs
@@ -1,3 +1,5 @@
+use log::info;
+
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
 use std::error::Error;
@@ -17,13 +19,13 @@ impl PsxAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Sony PlayStation (PSX)");
-        println!("Region:       {}", self.region);
-        println!("Code:         {}", self.code);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Sony PlayStation (PSX)");
+        info!("Region:       {}", self.region);
+        info!("Code:         {}", self.code);
 
         if self.code == "N/A" {
-            println!(
+            info!(
                 "Note: Executable prefix (SLUS/SLES/SLPS) not found in header area. Requires main data track (.bin or .iso)."
             );
         }

--- a/src/console/segacd.rs
+++ b/src/console/segacd.rs
@@ -1,8 +1,11 @@
+/// SegaCD header documentation referenced here:
 /// https://segaretro.org/ROM_header
+use std::error::Error;
+
+use log::{error, info};
+
 use crate::error::RomAnalyzerError;
 use crate::print_separator;
-use log::error;
-use std::error::Error;
 
 /// Struct to hold the analysis results for a Sega CD ROM.
 #[derive(Debug, PartialEq, Clone)]
@@ -21,11 +24,11 @@ impl SegaCdAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Sega CD / Mega CD");
-        println!("Signature:    {}", self.signature);
-        println!("Region Code:  0x{:02X}", self.region_code);
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Sega CD / Mega CD");
+        info!("Signature:    {}", self.signature);
+        info!("Region Code:  0x{:02X}", self.region_code);
+        info!("Region:       {}", self.region);
 
         print_separator();
     }

--- a/src/console/snes.rs
+++ b/src/console/snes.rs
@@ -1,5 +1,6 @@
+/// Super Nintendo header documentation referenced here:
 /// https://snes.nesdev.org/wiki/ROM_header
-use log::error;
+use log::{error, info};
 use std::error::Error;
 
 use crate::error::RomAnalyzerError;
@@ -31,12 +32,12 @@ impl SnesAnalysis {
     /// Prints the analysis results to the console.
     pub fn print(&self) {
         print_separator();
-        println!("Source:       {}", self.source_name);
-        println!("System:       Super Nintendo (SNES)");
-        println!("Game Title:   {}", self.game_title);
-        println!("Mapping:      {}", self.mapping_type);
-        println!("Region Code:  0x{:02X}", self.region_code);
-        println!("Region:       {}", self.region);
+        info!("Source:       {}", self.source_name);
+        info!("System:       Super Nintendo (SNES)");
+        info!("Game Title:   {}", self.game_title);
+        info!("Mapping:      {}", self.mapping_type);
+        info!("Region Code:  0x{:02X}", self.region_code);
+        info!("Region:       {}", self.region);
         print_separator();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod dispatcher;
 pub mod error;
 pub mod region;
 
+use log::info;
+
 use crate::console::gamegear::GameGearAnalysis;
 use crate::console::gb::GbAnalysis;
 use crate::console::gba::GbaAnalysis;
@@ -29,7 +31,7 @@ pub const SUPPORTED_ROM_EXTENSIONS: &[&str] = &[
 ];
 
 pub fn print_separator() {
-    println!("{}", "-".repeat(40));
+    info!("{}", "-".repeat(40));
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/region.rs
+++ b/src/region.rs
@@ -62,21 +62,21 @@ macro_rules! check_region_mismatch {
 
         if let (Some(inferred), Some(header)) = (inferred_region, header_region_norm) {
             if inferred != header {
-                println!("\n*** WARNING: POSSIBLE REGION MISMATCH! ***");
-                println!(
-                    "Source File:  {}",
+                ::log::error!(
+                    "\n*** WARNING: POSSIBLE REGION MISMATCH! ***\
+                     \nSource File:  {}\
+                     \nFilename suggests: {}\
+                     \nROM Header claims: {} (Header detail: '{}'\
+                     \nThe ROM may be mislabeled or have been patched.\
+                     \n*******************************************",
                     ::std::path::Path::new($source_name)
                         .file_name()
                         .unwrap_or_default()
-                        .to_string_lossy()
+                        .to_string_lossy(),
+                    inferred,
+                    header,
+                    $region_name
                 );
-                println!("Filename suggests: {}", inferred);
-                println!(
-                    "ROM Header claims: {} (Header detail: '{}')",
-                    header, $region_name
-                );
-                println!("The ROM may be mislabeled or have been patched.");
-                println!("*******************************************");
             }
         }
     };


### PR DESCRIPTION
We now default to info level, and -v jumps us all the way up to debug (which is used for extraneous information, like information on unpacking zips, decompressing hunks of a chd and getting mismatching SNES headers.)