### PR TITLE
Refactor CHD and ZIP processing

### DIFF
--- a/src/archive/zip.rs
+++ b/src/archive/zip.rs
@@ -2,20 +2,17 @@ use std::error::Error;
 use std::fs::File;
 use std::io::Read;
 
-use log::{debug, error};
+use log::debug;
 use zip::ZipArchive;
 
-use crate::RomAnalysisResult;
 use crate::SUPPORTED_ROM_EXTENSIONS;
 use crate::error::RomAnalyzerError;
 
 pub fn process_zip_file(
     file: File,
     original_filename: &str,
-    process_rom_data_fn: &dyn Fn(Vec<u8>, &str) -> Result<RomAnalysisResult, Box<dyn Error>>,
-) -> Result<RomAnalysisResult, Box<dyn Error>> {
+) -> Result<(Vec<u8>, String), Box<dyn Error>> {
     let mut archive = ZipArchive::new(file)?;
-    let mut found_rom = false;
 
     debug!("[+] Analyzing ZIP archive: {}", original_filename);
 
@@ -34,31 +31,15 @@ pub fn process_zip_file(
 
         if is_supported_rom {
             debug!("[+] Found supported ROM in zip: {}", entry_name);
-            found_rom = true;
             let mut data = Vec::new();
             file_in_zip.read_to_end(&mut data)?;
 
-            match process_rom_data_fn(data, &entry_name) {
-                Ok(analysis) => {
-                    return Ok(analysis);
-                }
-                Err(e) => {
-                    error!("[!] Analysis failed for {}: {}", entry_name, e);
-                }
-            }
+            return Ok((data, entry_name));
         }
     }
 
-    if found_rom {
-        Err(Box::new(RomAnalyzerError::new(&format!(
-            "No valid ROM header found in supported files within {}",
-            original_filename
-        )))
-        .into())
-    } else {
-        return Err(Box::new(RomAnalyzerError::new(&format!(
-            "No supported ROM files found within the zip archive: {}",
-            original_filename
-        ))));
-    }
+    Err(Box::new(RomAnalyzerError::new(&format!(
+        "No supported ROM files found within the zip archive: {}",
+        original_filename
+    ))))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::fs::{self, File};
 use std::path::Path;
 
 use clap::{ArgAction, Parser};
@@ -6,9 +5,7 @@ use env_logger;
 use log::{LevelFilter, error, info, warn};
 
 use rom_analyzer::RomAnalysisResult;
-use rom_analyzer::archive::chd::{ChdAnalysis, analyze_chd_file};
-use rom_analyzer::archive::zip::process_zip_file;
-use rom_analyzer::dispatcher::process_rom_data;
+use rom_analyzer::dispatcher::analyze_rom_data;
 use rom_analyzer::region::infer_region_from_filename;
 
 #[derive(Parser)]
@@ -29,38 +26,6 @@ struct Cli {
     /// Format output as JSON (suppresses everything except STDERR)
     #[clap(short, long, action = ArgAction::SetTrue)]
     json: bool,
-}
-
-fn get_file_extension_lowercase(file_path: &str) -> String {
-    std::path::Path::new(file_path)
-        .extension()
-        .and_then(std::ffi::OsStr::to_str)
-        .unwrap_or_default()
-        .to_lowercase()
-}
-
-fn process_single_file(
-    file_path: &str,
-    path: &Path,
-    file_name: &str,
-) -> Result<RomAnalysisResult, Box<dyn std::error::Error>> {
-    match get_file_extension_lowercase(file_path).as_str() {
-        "zip" => {
-            let file = File::open(path)?;
-            process_zip_file(file, file_name, &process_rom_data)
-        }
-        "chd" => {
-            let analysis_result = analyze_chd_file(path, file_name)?;
-            match analysis_result {
-                ChdAnalysis::SegaCD(analysis) => Ok(RomAnalysisResult::SegaCD(analysis)),
-                ChdAnalysis::PSX(analysis) => Ok(RomAnalysisResult::PSX(analysis)),
-            }
-        }
-        _ => {
-            let data = fs::read(path)?;
-            process_rom_data(data, file_name)
-        }
-    }
 }
 
 fn main() {
@@ -97,15 +62,7 @@ fn main() {
             continue;
         }
 
-        let file_name = if let Some(name) = path.file_name().and_then(|s| s.to_str()) {
-            name
-        } else {
-            error!("Could not get a valid UTF-8 filename for: {}", file_path);
-            had_error = true;
-            continue;
-        };
-
-        let result = process_single_file(file_path, path, file_name);
+        let result = analyze_rom_data(file_path);
         match result {
             Ok(analysis) => {
                 if cli.json {


### PR DESCRIPTION
Refactor CHD and ZIP processing to return the inner data rather than process it. This allows us to centralize the process_rom_data logic.

This is in an effort to make less functions public.